### PR TITLE
Include migrations with files published on Hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Terminator.MixProject do
 
   defp package() do
     [
-      files: ~w(lib .formatter.exs mix.exs README*),
+      files: ~w(lib priv/repo/migrations .formatter.exs mix.exs README*),
       licenses: ["GPL"],
       links: %{"GitHub" => "https://github.com/MilosMosovsky/terminator"}
     ]


### PR DESCRIPTION
When specifying Terminator as a dependency from Hex, migrations aren't found because they're not included in the package files.

```
** (Mix) Could not find migrations directory "deps/terminator/priv/repo/migrations"
for repo Terminator.Repo.

This may be because you are in a new project and the
migration directory has not been created yet. Creating an
empty directory at the path above will fix this error.

If you expected existing migrations to be found, please
make sure your repository has been properly configured
and the configured path exists.
```